### PR TITLE
Rename devices

### DIFF
--- a/src/main/kotlin/dev/polek/adbwifi/model/Device.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/model/Device.kt
@@ -6,7 +6,7 @@ data class Device(
     val id: String,
     val serialNumber: String,
     val name: String,
-    val customName: String? = null,
+    var customName: String? = null,
     val address: Address?,
     val port: Int,
     val androidVersion: String,

--- a/src/main/kotlin/dev/polek/adbwifi/model/Device.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/model/Device.kt
@@ -6,6 +6,7 @@ data class Device(
     val id: String,
     val serialNumber: String,
     val name: String,
+    val customName: String? = null,
     val address: Address?,
     val port: Int,
     val androidVersion: String,

--- a/src/main/kotlin/dev/polek/adbwifi/model/PinnedDevice.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/model/PinnedDevice.kt
@@ -4,6 +4,7 @@ data class PinnedDevice(
     val id: String,
     val serialNumber: String,
     val name: String,
+    val customName: String? = null,
     val address: String,
     val port: Int,
     val androidVersion: String,

--- a/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
@@ -20,18 +20,14 @@ class PinDeviceService : PersistentStateComponent<PinDeviceService> {
     var pinnedDevices: List<PinnedDevice> = listOf()
 
     fun addPreviouslyConnectedDevice(device: Device) {
-        if (device.connectionType == WIFI && device.address?.ip!!.isNotEmpty() && !pinnedDevices.contains(device)) {
-            pinnedDevices = pinnedDevices.add(device)
-        }
+        if (device.connectionType != WIFI) return
+        if (device.address?.ip.isNullOrBlank()) return
+        if (pinnedDevices.contains(device)) return
+        pinnedDevices = pinnedDevices.add(device)
     }
 
     fun addPreviouslyConnectedDevices(devices: List<Device>) {
-        for (device in devices) {
-            if (device.connectionType != WIFI) continue
-            if (device.address?.ip.isNullOrBlank()) continue
-            if (pinnedDevices.contains(device)) continue
-            pinnedDevices = pinnedDevices.add(device)
-        }
+        devices.forEach { addPreviouslyConnectedDevice(it) }
     }
 
     fun removePreviouslyConnectedDevice(device: Device) {

--- a/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
@@ -20,14 +20,18 @@ class PinDeviceService : PersistentStateComponent<PinDeviceService> {
     var pinnedDevices: List<PinnedDevice> = listOf()
 
     fun addPreviouslyConnectedDevice(device: Device) {
-        if (device.connectionType != WIFI) return
-        if (device.address?.ip.isNullOrBlank()) return
-        if (pinnedDevices.contains(device)) return
-        pinnedDevices = pinnedDevices.add(device)
+        if (device.connectionType == WIFI && device.address?.ip!!.isNotEmpty() && !pinnedDevices.contains(device)) {
+            pinnedDevices = pinnedDevices.add(device)
+        }
     }
 
     fun addPreviouslyConnectedDevices(devices: List<Device>) {
-        devices.forEach { addPreviouslyConnectedDevice(it) }
+        for (device in devices) {
+            if (device.connectionType != WIFI) continue
+            if (device.address?.ip.isNullOrBlank()) continue
+            if (pinnedDevices.contains(device)) continue
+            pinnedDevices = pinnedDevices.add(device)
+        }
     }
 
     fun removePreviouslyConnectedDevice(device: Device) {

--- a/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
@@ -19,10 +19,13 @@ class PinDeviceService : PersistentStateComponent<PinDeviceService> {
     @OptionTag(converter = PinnedDeviceListConverter::class)
     var pinnedDevices: List<PinnedDevice> = listOf()
 
+    fun updatePreviouslyConnectedDevice(device: Device){
+        removePreviouslyConnectedDevice(device)
+        addPreviouslyConnectedDevice(device)
+    }
+
     fun addPreviouslyConnectedDevice(device: Device) {
-        if (device.connectionType == WIFI && device.address?.ip!!.isNotEmpty() && !pinnedDevices.contains(device)) {
-            pinnedDevices = pinnedDevices.add(device)
-        }
+        pinnedDevices = pinnedDevices.add(device)
     }
 
     fun addPreviouslyConnectedDevices(devices: List<Device>) {

--- a/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
@@ -24,7 +24,7 @@ class PinDeviceService : PersistentStateComponent<PinDeviceService> {
         addPreviouslyConnectedDevice(device)
     }
 
-    fun addPreviouslyConnectedDevice(device: Device) {
+    private fun addPreviouslyConnectedDevice(device: Device) {
         pinnedDevices = pinnedDevices.add(device)
     }
 

--- a/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
@@ -19,6 +19,12 @@ class PinDeviceService : PersistentStateComponent<PinDeviceService> {
     @OptionTag(converter = PinnedDeviceListConverter::class)
     var pinnedDevices: List<PinnedDevice> = listOf()
 
+    fun addPreviouslyConnectedDevice(device: Device) {
+        if (device.connectionType == WIFI && device.address?.ip!!.isNotEmpty() && !pinnedDevices.contains(device)) {
+            pinnedDevices.add(device)
+        }
+    }
+
     fun addPreviouslyConnectedDevices(devices: List<Device>) {
         for (device in devices) {
             if (device.connectionType != WIFI) continue
@@ -52,6 +58,7 @@ class PinDeviceService : PersistentStateComponent<PinDeviceService> {
                 id = device.id,
                 serialNumber = device.serialNumber,
                 name = device.name,
+                customName = device.customName,
                 address = address,
                 port = device.port,
                 androidVersion = device.androidVersion,

--- a/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/services/PinDeviceService.kt
@@ -21,7 +21,7 @@ class PinDeviceService : PersistentStateComponent<PinDeviceService> {
 
     fun addPreviouslyConnectedDevice(device: Device) {
         if (device.connectionType == WIFI && device.address?.ip!!.isNotEmpty() && !pinnedDevices.contains(device)) {
-            pinnedDevices.add(device)
+            pinnedDevices = pinnedDevices.add(device)
         }
     }
 

--- a/src/main/kotlin/dev/polek/adbwifi/ui/model/DeviceViewModel.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/ui/model/DeviceViewModel.kt
@@ -41,7 +41,7 @@ data class DeviceViewModel(
             val device = this
             return DeviceViewModel(
                 device = device,
-                titleText = device.name,
+                titleText = device.customName ?: device.name,
                 subtitleText = device.subtitleText(),
                 subtitleIcon = device.addressIcon(),
                 icon = device.icon(),
@@ -57,6 +57,7 @@ data class DeviceViewModel(
                 id = this.id,
                 serialNumber = this.serialNumber,
                 name = this.name,
+                customName = this.customName,
                 address = Address("", this.address),
                 port = this.port,
                 androidVersion = this.androidVersion,
@@ -66,7 +67,7 @@ data class DeviceViewModel(
             )
             return DeviceViewModel(
                 device = device,
-                titleText = device.name,
+                titleText = device.customName ?: device.name,
                 subtitleText = device.subtitleText(),
                 subtitleIcon = device.addressIcon(),
                 icon = device.icon(),

--- a/src/main/kotlin/dev/polek/adbwifi/ui/presenter/ToolWindowPresenter.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/ui/presenter/ToolWindowPresenter.kt
@@ -235,7 +235,7 @@ class ToolWindowPresenter : BasePresenter<ToolWindowView>() {
                     device.serialNumber == pinnedDevice.serialNumber && device.address == pinnedDevice.address
                 } == null
             }
-            .sortedBy { it.name }
+            .sortedBy { it.customName ?: it.name }
             .map { it.toViewModel() }
             .toList()
     }

--- a/src/main/kotlin/dev/polek/adbwifi/ui/view/AdbWiFiToolWindow.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/ui/view/AdbWiFiToolWindow.kt
@@ -70,6 +70,10 @@ class AdbWiFiToolWindow(
         override fun onCopyDeviceAddressClicked(device: DeviceViewModel) {
             presenter.onCopyDeviceAddressClicked(device)
         }
+
+        override fun onRenameDeviceClicked(device: DeviceViewModel) {
+            RenameDeviceDialogWrapper(device).show()
+        }
     }
 
     private val splitter = JBSplitter(true, "AdbWifi.ShellPaneProportion", DEFAULT_PANEL_PROPORTION)

--- a/src/main/kotlin/dev/polek/adbwifi/ui/view/DevicePanel.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/ui/view/DevicePanel.kt
@@ -184,6 +184,12 @@ class DevicePanel(device: DeviceViewModel) : JBPanel<DevicePanel>(GridBagLayout(
     private fun openDeviceMenu(device: DeviceViewModel, event: MouseEvent) {
         val menu = JBPopupMenu()
 
+        val renameDeviceItem = JBMenuItem(PluginBundle.message("renameDevice"))
+        renameDeviceItem.addActionListener {
+            listener?.onRenameDeviceClicked(device)
+        }
+        menu.add(renameDeviceItem)
+
         val copyIdItem = JBMenuItem(PluginBundle.message("copyDeviceIdMenuItem"), AllIcons.Actions.Copy)
         copyIdItem.addActionListener {
             listener?.onCopyDeviceIdClicked(device)
@@ -207,6 +213,7 @@ class DevicePanel(device: DeviceViewModel) : JBPanel<DevicePanel>(GridBagLayout(
         fun onRemoveDeviceClicked(device: DeviceViewModel)
         fun onCopyDeviceIdClicked(device: DeviceViewModel)
         fun onCopyDeviceAddressClicked(device: DeviceViewModel)
+        fun onRenameDeviceClicked(device: DeviceViewModel)
     }
 
     private companion object {

--- a/src/main/kotlin/dev/polek/adbwifi/ui/view/RenameDeviceDialogWrapper.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/ui/view/RenameDeviceDialogWrapper.kt
@@ -84,13 +84,12 @@ class RenameDeviceDialogWrapper(private val deviceViewModel: DeviceViewModel) : 
     private fun renameDevice() {
         val pinService = service<PinDeviceService>()
         renameDeviceJob = appCoroutineScope.launch(Dispatchers.IO) {
-            pinService.removePreviouslyConnectedDevice(deviceViewModel.device)
             val customName = customNameField.text.trim()
             withContext(Dispatchers.Main) {
                 customNameField.text = customName
                 customNameField.requestFocusInWindow()
                 deviceViewModel.device.customName = customName
-                pinService.addPreviouslyConnectedDevice(deviceViewModel.device)
+                pinService.updatePreviouslyConnectedDevice(deviceViewModel.device)
             }
         }
         dispose()

--- a/src/main/kotlin/dev/polek/adbwifi/ui/view/RenameDeviceDialogWrapper.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/ui/view/RenameDeviceDialogWrapper.kt
@@ -1,0 +1,102 @@
+package dev.polek.adbwifi.ui.view
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.JBUI
+import dev.polek.adbwifi.PluginBundle
+import dev.polek.adbwifi.services.PinDeviceService
+import dev.polek.adbwifi.ui.model.DeviceViewModel
+import dev.polek.adbwifi.utils.GridBagLayoutPanel
+import dev.polek.adbwifi.utils.appCoroutineScope
+import dev.polek.adbwifi.utils.makeMonospaced
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.awt.GridBagConstraints
+import javax.swing.Action
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
+
+class RenameDeviceDialogWrapper(private val deviceViewModel: DeviceViewModel) : DialogWrapper(true) {
+
+    private lateinit var customNameLabel: JBLabel
+    private lateinit var customNameField: JBTextField
+    private lateinit var renameButton: JButton
+
+    private var renameDeviceJob: Job? = null
+
+    init {
+        init()
+        isResizable = false
+        title = PluginBundle.message("name")
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = GridBagLayoutPanel()
+
+        customNameLabel = JBLabel(PluginBundle.message("renameDeviceLabel"))
+        panel.add(
+                customNameLabel,
+                GridBagConstraints().apply {
+                    gridx = 0
+                }
+        )
+
+        customNameField = JBTextField(25)
+        customNameField.makeMonospaced()
+        customNameField.document.addDocumentListener(object : DocumentListener {
+            override fun insertUpdate(e: DocumentEvent) = updateRenameButton()
+            override fun removeUpdate(e: DocumentEvent) = updateRenameButton()
+            override fun changedUpdate(e: DocumentEvent) = updateRenameButton()
+        })
+        panel.add(
+                customNameField,
+                GridBagConstraints().apply {
+                    gridx = 1
+                    fill = GridBagConstraints.HORIZONTAL
+                    weightx = 1.0
+                    insets = JBUI.insets(0, 5)
+                }
+        )
+        renameButton = JButton(PluginBundle.message("renameButton"))
+        renameButton.addActionListener {
+            renameDevice()
+        }
+        panel.add(
+                renameButton,
+                GridBagConstraints().apply {
+                    gridx = 3
+                }
+        )
+
+        updateRenameButton()
+
+        return panel
+    }
+
+    override fun createActions(): Array<Action> = emptyArray()
+
+    private fun renameDevice() {
+        val pinService = service<PinDeviceService>()
+        renameDeviceJob = appCoroutineScope.launch(Dispatchers.IO) {
+            pinService.removePreviouslyConnectedDevice(deviceViewModel.device)
+            val customName = customNameField.text.trim()
+            withContext(Dispatchers.Main) {
+                customNameField.text = customName
+                customNameField.requestFocusInWindow()
+                deviceViewModel.device.customName = customName
+                pinService.addPreviouslyConnectedDevice(deviceViewModel.device)
+            }
+        }
+        dispose()
+    }
+
+    private fun updateRenameButton() {
+        renameButton.isEnabled = customNameField.text.isNotBlank()
+    }
+}

--- a/src/main/kotlin/dev/polek/adbwifi/ui/view/RenameDeviceDialogWrapper.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/ui/view/RenameDeviceDialogWrapper.kt
@@ -9,12 +9,7 @@ import dev.polek.adbwifi.PluginBundle
 import dev.polek.adbwifi.services.PinDeviceService
 import dev.polek.adbwifi.ui.model.DeviceViewModel
 import dev.polek.adbwifi.utils.GridBagLayoutPanel
-import dev.polek.adbwifi.utils.appCoroutineScope
 import dev.polek.adbwifi.utils.makeMonospaced
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.awt.GridBagConstraints
 import javax.swing.Action
 import javax.swing.JButton
@@ -27,8 +22,6 @@ class RenameDeviceDialogWrapper(private val deviceViewModel: DeviceViewModel) : 
     private lateinit var customNameLabel: JBLabel
     private lateinit var customNameField: JBTextField
     private lateinit var renameButton: JButton
-
-    private var renameDeviceJob: Job? = null
 
     init {
         init()
@@ -83,15 +76,11 @@ class RenameDeviceDialogWrapper(private val deviceViewModel: DeviceViewModel) : 
 
     private fun renameDevice() {
         val pinService = service<PinDeviceService>()
-        renameDeviceJob = appCoroutineScope.launch(Dispatchers.IO) {
-            val customName = customNameField.text.trim()
-            withContext(Dispatchers.Main) {
-                customNameField.text = customName
-                customNameField.requestFocusInWindow()
-                deviceViewModel.device.customName = customName
-                pinService.updatePreviouslyConnectedDevice(deviceViewModel.device)
-            }
-        }
+        val customName = customNameField.text.trim()
+        customNameField.text = customName
+        customNameField.requestFocusInWindow()
+        deviceViewModel.device.customName = customName
+        pinService.updatePreviouslyConnectedDevice(deviceViewModel.device)
         dispose()
     }
 

--- a/src/main/kotlin/dev/polek/adbwifi/ui/view/RenameDeviceDialogWrapper.kt
+++ b/src/main/kotlin/dev/polek/adbwifi/ui/view/RenameDeviceDialogWrapper.kt
@@ -41,10 +41,10 @@ class RenameDeviceDialogWrapper(private val deviceViewModel: DeviceViewModel) : 
 
         customNameLabel = JBLabel(PluginBundle.message("renameDeviceLabel"))
         panel.add(
-                customNameLabel,
-                GridBagConstraints().apply {
-                    gridx = 0
-                }
+            customNameLabel,
+            GridBagConstraints().apply {
+                gridx = 0
+            }
         )
 
         customNameField = JBTextField(25)
@@ -55,23 +55,23 @@ class RenameDeviceDialogWrapper(private val deviceViewModel: DeviceViewModel) : 
             override fun changedUpdate(e: DocumentEvent) = updateRenameButton()
         })
         panel.add(
-                customNameField,
-                GridBagConstraints().apply {
-                    gridx = 1
-                    fill = GridBagConstraints.HORIZONTAL
-                    weightx = 1.0
-                    insets = JBUI.insets(0, 5)
-                }
+            customNameField,
+            GridBagConstraints().apply {
+                gridx = 1
+                fill = GridBagConstraints.HORIZONTAL
+                weightx = 1.0
+                insets = JBUI.insets(0, 5)
+            }
         )
         renameButton = JButton(PluginBundle.message("renameButton"))
         renameButton.addActionListener {
             renameDevice()
         }
         panel.add(
-                renameButton,
-                GridBagConstraints().apply {
-                    gridx = 3
-                }
+            renameButton,
+            GridBagConstraints().apply {
+                gridx = 3
+            }
         )
 
         updateRenameButton()

--- a/src/main/resources/messages/PluginBundle.properties
+++ b/src/main/resources/messages/PluginBundle.properties
@@ -36,3 +36,7 @@ scrcpyDocLabel=More info
 submitReportActionText=Report to Developer
 submitReportProgressText=Sending error report
 deviceIpLabel=Device IP:
+renameDevice=Rename Device
+renameDeviceLabel=Device Name:
+renameButton=Rename
+


### PR DESCRIPTION
@y-polek 
Rename previously connected devices

**Reason:**
As a developer who works with android devices using the ADB Wi-Fi tool, there can be a lot of previously connected devices with the same title.

Devices could only differ by IP Address.

This PR is to allow user to rename previously connected devices to help identify and distinguish easily.

Feel free to leave comments and suggestions

Notes:
The custom name only appears when the device is disconnected, when the device is connected, it will display the device name.
If you rename the device that is currently connected, the rename will appear once the device is disconnected